### PR TITLE
Add --outfile arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Options:
                specified, the bundle is inlined.
 -r, --reload   Auto reload on change.
 -t, --title    Set the document title. Defaults to "Consolify".
+-o, --outfile  Write the standalone HTML page to the supplied path as well as
+               passing it through to browserify
 ```
 
 ## Mocha support

--- a/lib/consolify.js
+++ b/lib/consolify.js
@@ -25,6 +25,16 @@ var markerSourceOffset = '/*source_offset*/';
 var markerScript       = '/*script*/';
 var markerBundle       = '<!--bundle-->';
 
+function resolvePath(outfile, bundle) {
+  if (!outfile) {
+    return bundle;
+  }
+  // if we know where the html is going to be written we can
+  // ensure the <script> tag points to the correct relative
+  // path, see https://github.com/mantoni/mochify.js/issues/140
+  return path.relative(path.dirname(outfile), bundle);
+}
+
 function generate(title, template, styles, script, bundle, reload, error,
     outfile, out) {
   var mapped = mapper.extract(script);
@@ -40,6 +50,7 @@ function generate(title, template, styles, script, bundle, reload, error,
   }
 
   var html = '';
+  var bpath = resolvePath(outfile, bundle);
   var p = [
     [markerTitle, title],
     [markerStyles, '<style>' + styles + '</style>'],
@@ -47,7 +58,7 @@ function generate(title, template, styles, script, bundle, reload, error,
     [markerSourceMap, JSON.stringify(mapped.map)],
     [markerSourceOffset, String(styles.split('\n').length + 12)],
     [markerScript, js],
-    [markerBundle, bundle ? '<script src="' + bundle + '"></script>' : '']
+    [markerBundle, bpath ? '<script src="' + bpath + '"></script>' : '']
   ]
     .reduce(function (p, v) {
       var m = v[0];

--- a/lib/consolify.js
+++ b/lib/consolify.js
@@ -11,6 +11,7 @@ var through = require('through2');
 var mapper  = require('source-mapper');
 var fs      = require('fs');
 var path    = require('path');
+var util    = require('./util');
 
 var template = __dirname + '/consolify.html';
 var styles   = __dirname + '/consolify.css';
@@ -25,7 +26,7 @@ var markerScript       = '/*script*/';
 var markerBundle       = '<!--bundle-->';
 
 function generate(title, template, styles, script, bundle, reload, error,
-    out) {
+    outfile, out) {
   var mapped = mapper.extract(script);
   var js = mapped.js;
   if (reload) {
@@ -38,6 +39,7 @@ function generate(title, template, styles, script, bundle, reload, error,
     js = '';
   }
 
+  var html = '';
   var p = [
     [markerTitle, title],
     [markerStyles, '<style>' + styles + '</style>'],
@@ -50,18 +52,23 @@ function generate(title, template, styles, script, bundle, reload, error,
     .reduce(function (p, v) {
       var m = v[0];
       var n = template.indexOf(m, p);
-      out.write(template.substring(p, n));
-      out.write(v[1]);
+      html += template.substring(p, n);
+      html += v[1];
       return n + m.length;
     }, 0);
-  out.write(template.substring(p));
+  html += template.substring(p);
+  out.write(html);
+
+  var tasks = [];
   if (bundle) {
-    fs.writeFile(bundle, script, function () {
-      out.end();
-    });
-  } else {
-    out.end();
+    tasks.push(fs.writeFile.bind(fs, bundle, script));
   }
+  if (outfile) {
+    tasks.push(fs.writeFile.bind(fs, outfile, html));
+  }
+  util.series(tasks, function () {
+    out.end();
+  });
 }
 
 
@@ -69,6 +76,7 @@ module.exports = function (b, options) {
   b.add('./' + path.relative(process.cwd(), path.resolve(__dirname, '..')));
   var title = options.title || options.t || 'Consolify';
   var bundle = options.bundle || options.b || '';
+  var outfile = options.outfile || options.o || '';
   var templateContent;
   var stylesContent;
   var reloadContent;
@@ -119,10 +127,12 @@ module.exports = function (b, options) {
         bundle,
         reloadContent,
         err,
+        outfile,
         out
       );
+
       if (done) {
-        done();
+        out.on('end', done);
       }
     };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,30 @@
+/*
+ * consolify
+ *
+ * Copyright (c) 2013-2014 Maximilian Antoni <mail@maxantoni.de>
+ *
+ * @license MIT
+ */
+'use strict';
+
+// series invokes the supplied array of functions (tasks) in order 
+// before finally the supplied 'done' callback when all tasks have
+// been executed.  Each task will be invoked with a callback function 
+// which it should invoke when it has completed; should the task 
+// supply an error to the callback then execution of subsiquent tasks 
+// will be halted and the error propogated to the supplied 'done' 
+// callback
+exports.series = function (tasks, done) {
+  function runTask(i) {
+    if (i >= tasks.length) {
+      return done();
+    }
+    tasks[i](function (err) {
+      if (err) {
+        return done(err);
+      }
+      runTask(i + 1);
+    });
+  }
+  runTask(0);
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "devDependencies" : {
     "jslint"        : "^0.8",
     "mocha"         : "^2.3.4",
-    "browserify"    : "^13.0.0"
+    "browserify"    : "^13.0.0",
+    "tmp"           : "^0.0.28"
   },
   "repository"      : {
     "type"          : "git",

--- a/test/consolify-test.js
+++ b/test/consolify-test.js
@@ -193,4 +193,24 @@ describe('bundle', function () {
       }));
   }));
 
+  it('resolves the bundle path relative to the html',
+    sandbox(function (done, tmpdir) {
+      fs.mkdir(tmpdir + '/tmp', function (err) {
+        if (err) {
+          return done(err);
+        }
+        bundle('console.js', {
+          outfile : tmpdir + 'tmp/out.html',
+          bundle : tmpdir + 'tmp/bundle.js'
+        })
+          .pipe(collect(function (h) {
+            assert.notEqual(
+              h.indexOf('<script src="bundle.js">'),
+              -1
+            );
+            done();
+          }));
+      });
+    }));
+
 });

--- a/test/fixture/sandbox.js
+++ b/test/fixture/sandbox.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var tmp  = require('tmp');
+
+// sandbox creates a temporary directory which will be automatically
+// removed after the testcase completes.
+function sandbox(testfn) {
+  return function (done) {
+    var tmpOpts = {
+      unsafeCleanup: true
+    };
+    tmp.dir(tmpOpts, function (err, tmpdir) {
+      if (err) {
+        return done(err);
+      }
+      testfn(done, tmpdir);
+    });
+  };
+}
+
+module.exports = sandbox;


### PR DESCRIPTION
See https://github.com/mantoni/mochify.js/issues/140 for justification.

* Add `--outfile` arg: writes the html file to a given path as well as passing it through to browserify.
* Add file-system sandbox for testcases: removes the manual fs cleanup
* Resolve the bundle relative to the outfile.